### PR TITLE
Fix error Cannot read property 'getBoundingClientRect' of undefined

### DIFF
--- a/src/components/trend-chart.js
+++ b/src/components/trend-chart.js
@@ -165,8 +165,10 @@ export default {
       );
     },
     mouseMove(e) {
-      const rect = this.$refs.chart.getBoundingClientRect();
-      this.activeLine = this.getNearestCoordinate(e.clientX - rect.left);
+      if (this.$refs.chart !== undefined) {
+        const rect = this.$refs.chart.getBoundingClientRect();
+        this.activeLine = this.getNearestCoordinate(e.clientX - rect.left);
+      }
     },
     mouseOut() {
       this.activeLine = null;


### PR DESCRIPTION
It happens sometime in chrome window